### PR TITLE
Update install.sh to work on other distros

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -58,7 +58,11 @@ if ! command_exists impacket-GetUserSPNs; then
     if apt-cache show impacket-scripts &>/dev/null; then
         sudo apt install -y impacket-scripts
     else
-        sudo git clone https://github.com/SecureAuthCorp/impacket.git /opt/impacket
+        if [ -d "/opt/impacket" ]; then
+            echo "[!] /opt/impacket already exists, skipping clone."
+        else
+            sudo git clone https://github.com/SecureAuthCorp/impacket.git /opt/impacket
+        fi
         sudo $PIP_CMD install /opt/impacket
     fi
 fi

--- a/install.sh
+++ b/install.sh
@@ -4,10 +4,8 @@ set -euo pipefail
 # Determine which pip to use
 if command -v pip3 &>/dev/null; then
     PIP_CMD="pip3"
-elif command -v pip &>/dev/null; then
-    PIP_CMD="pip"
 else
-    echo "[!] pip not found, installing python3-pip..."
+    echo "[!] pip3 not found, installing python3-pip..."
     sudo apt update
     sudo apt install -y python3-pip
     PIP_CMD="pip3"
@@ -61,7 +59,7 @@ if ! command_exists impacket-GetUserSPNs; then
         if [ -d "/opt/impacket" ]; then
             echo "[!] /opt/impacket already exists, skipping clone."
         else
-            sudo git clone https://github.com/SecureAuthCorp/impacket.git /opt/impacket
+            sudo git clone https://github.com/fortra/impacket.git /opt/impacket
         fi
         sudo $PIP_CMD install /opt/impacket
     fi
@@ -70,8 +68,8 @@ fi
 # Check and install feroxbuster
 if ! command_exists feroxbuster; then
     echo "[*] Installing feroxbuster..."
-    if command_exists snap; then
-        sudo snap install feroxbuster
+    if apt-cache show feroxbuster &>/dev/null; then
+        sudo apt install -y feroxbuster
     else
         curl -sL https://github.com/epi052/feroxbuster/releases/latest/download/feroxbuster_amd64.deb.zip -o feroxbuster.deb.zip
         unzip -o feroxbuster.deb.zip

--- a/install.sh
+++ b/install.sh
@@ -20,7 +20,7 @@ command_exists() {
 
 sudo rm -rf /opt/CTFEnum
 
-sudo python3 -m $PIP_CMD install --upgrade colorama
+sudo $PIP_CMD install --upgrade colorama
 
 sudo apt update
 

--- a/install.sh
+++ b/install.sh
@@ -18,7 +18,15 @@ command_exists() {
 
 sudo rm -rf /opt/CTFEnum
 
-sudo $PIP_CMD install --upgrade colorama
+# Detect WSL
+PIP_EXTRA_ARGS=""
+if grep -qi microsoft /proc/sys/kernel/osrelease; then
+    echo "[*] Detected WSL - adding --break-system-packages to pip install"
+    PIP_EXTRA_ARGS="--break-system-packages"
+fi
+
+sudo $PIP_CMD install --upgrade colorama $PIP_EXTRA_ARGS
+
 
 sudo apt update
 
@@ -40,7 +48,13 @@ install_tool() {
 }
 
 # Check and install seclists
-install_tool seclists seclists seclists "https://github.com/danielmiessler/SecLists.git" "/opt/SecLists"
+if [ ! -d "/usr/share/SecLists" ]; then
+    echo "[*] Cloning SecLists..."
+    sudo git clone https://github.com/danielmiessler/SecLists.git /usr/share/SecLists
+else
+    echo "[*] SecLists already installed at /usr/share/SecLists"
+fi
+
 # nmap
 install_tool nmap nmap "" "" ""
 # gobuster
@@ -74,7 +88,7 @@ if ! command_exists feroxbuster; then
         curl -sL https://github.com/epi052/feroxbuster/releases/latest/download/feroxbuster_amd64.deb.zip -o feroxbuster.deb.zip
         unzip -o feroxbuster.deb.zip
         sudo apt install -y ./feroxbuster_*_amd64.deb
-        rm feroxbuster.deb.zip
+        rm -f feroxbuster.deb.zip feroxbuster_*_amd64.deb
     fi
 fi
 


### PR DESCRIPTION
Cheers,

First, nice tool, I used it for one of the room you built in tryhackme and it's pleasant for automating part of the enum, but I had an issue when using install.sh in the Tryhackme's Attackbox since its Ubuntu and some of your install commands assume you are using kali and I had to do some manual install of packages. I made some edits to the install.sh so it works on other distros too.

changes and why

- added set -euo pipefail to make the script stop on errors or bad variables
- Fixed pip install logic: removed --break-system-packages since it caused issues in our Ubuntu environment due to unsupported pip version or restricted setup
- now checks if pip3 or pip exists, installs pip if not
- replaced repeated apt installs with a function (install_tool) to handle apt, snap, or git clone
- added fallback installs for seclists, impacket, and feroxbuster when apt doesn’t work
- changed hardcoded chown 1000:1000 to use the current user's uid/gid so it works for everyone
- updated the ctfenum launcher:
- moved logic into a heredoc for cleaner script
- changed "$1" to "$@" so it passes all arguments
- still puts it in /usr/sbin, but could be changed to /usr/local/bin later if needed
- kept everything else mostly the same, just safer and more compatible outside kali


